### PR TITLE
Fix ability for customers to use previously stored payment method

### DIFF
--- a/view/frontend/web/js/model/place-order-mixin.js
+++ b/view/frontend/web/js/model/place-order-mixin.js
@@ -22,6 +22,7 @@ define([
                             'og_optins': JSON.stringify(productIds)
                         }
                     }
+                    paymentData['additional_data']['customer_id'] = customerData.id;
                 }
             }
 


### PR DESCRIPTION
Right now when a customer attempts to check out with a subscription, they are unable to use an existing stored payment method. This was due to the lookup being done without a customer id, resulting in a php error. This PR attempts to use the globally available `customerData.id` to set this data.