### PR TITLE
Add PayPal support for purchase post

### DIFF
--- a/Helper/ConfigHelper.php
+++ b/Helper/ConfigHelper.php
@@ -3,13 +3,14 @@
 namespace Ordergroove\Subscription\Helper;
 
 use PayPal\Braintree\Model\Ui\ConfigProvider;
+use PayPal\Braintree\Model\Ui\PayPal\ConfigProvider as PayPalConfigProvider;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 class ConfigHelper
 {
-    const ALLOWED_GATEWAYS = [ConfigProvider::CODE];
+    const ALLOWED_GATEWAYS = [ConfigProvider::CODE, PayPalConfigProvider::PAYPAL_CODE];
     /**
      * @var ScopeConfigInterface
      */

--- a/Helper/PurchasePost/DataMapper/DataMap.php
+++ b/Helper/PurchasePost/DataMapper/DataMap.php
@@ -82,18 +82,28 @@ class DataMap
 
         $ccExp = $this->dataMapHelper->getExpiration($payment, $websiteId);
 
-        if ($token && $ccExp) {
+        if ($token) {
             $map['payment'] = [
                 'token_id' => $token,
-                'cc_exp_date' => urlencode($ccExp),
-                'cc_type' => self::ORDERGROOVE_CARD_TYPE_MAP[$payment->getCcType()],
             ];
+
+            if ($payment->getCcType()) {
+                $map['payment']['cc_type'] = self::ORDERGROOVE_CARD_TYPE_MAP[$payment->getCcType()];
+                $map['payment']['payment_method'] = 'credit card';
+
+                if ($ccExp) {
+                    $map['payment']['cc_exp_date'] = urlencode($ccExp);
+                }
+            }
+            
+            // If PayPal is used set/reset the payment_method to paypal
+            if ($order->getPayment()->getMethod() == "braintree_paypal") {
+                $map['payment']['payment_method'] = 'paypal';
+            }
         }
 
         $allProducts = $this->dataMapHelper->getProducts($order);
-
         $map['products'] = $allProducts;
-
         return $map;
     }
 }


### PR DESCRIPTION
This will add PayPal through Braintree support for the purchase post (call made during subscription creation)

Token format:
`(website id)::(token)::braintree_paypal`