### PR TITLE
Fix recurring order credit card type check

### DIFF
--- a/Helper/RecurringOrderHelper/BraintreeSearchHelper.php
+++ b/Helper/RecurringOrderHelper/BraintreeSearchHelper.php
@@ -69,7 +69,7 @@ class BraintreeSearchHelper
         );
 
         $concatExpDate = $retrievedData['creditCard']['expirationMonth'] . '/' . $retrievedData['creditCard']['expirationYear'];
-        if ($creditCardData['orderCcType'] !== $retrievedData['creditCard']['cardType']) {
+        if (trim(strtolower($creditCardData['orderCcType'])) !== trim(strtolower($retrievedData['creditCard']['cardType']))) {
             throw new RecurringOrderException(__("Invalid Credit Card Type"), null, "100");
         }
 


### PR DESCRIPTION
This fix will ensure that we're normalizing the data to lower case and are trimming all leading and trailing white-space before we do our comparison on the values. This will solve for certain cases like `Master Card` - where Ordergroove recurring order XML contains `Mastercard` while the type stored in Braintree is `MasterCard`.