### PR TITLE
Fix flat rate shipping support

### DIFF
--- a/Model/RecurringOrder/CreateRecurringOrder.php
+++ b/Model/RecurringOrder/CreateRecurringOrder.php
@@ -361,7 +361,9 @@ class CreateRecurringOrder
 
             $shippingAddress->setCollectShippingRates(true)
                 ->collectShippingRates()
-                ->setShippingMethod('flatrate_flatrate');
+                ->setShippingMethod('flatrate_flatrate')
+                ->setShippingAmount(floatval($orderData['shipping']));
+            
             $quote->setPaymentMethod($validateTokenData['method']);
             $quote->setInventoryProcessed(false);
             $quote->setIsMultiShipping(0);

--- a/Model/RecurringOrder/CreateRecurringOrder.php
+++ b/Model/RecurringOrder/CreateRecurringOrder.php
@@ -361,8 +361,7 @@ class CreateRecurringOrder
 
             $shippingAddress->setCollectShippingRates(true)
                 ->collectShippingRates()
-                ->setShippingMethod('flatrate_flatrate')
-                ->setShippingAmount(floatval($orderData['shipping']));
+                ->setShippingMethod('flatrate_flatrate');
             
             $quote->setPaymentMethod($validateTokenData['method']);
             $quote->setInventoryProcessed(false);
@@ -389,6 +388,7 @@ class CreateRecurringOrder
 
             $extraPaymentData = $this->createRecurringOrderHelper->createPaymentMethodNonce($validateTokenData, $customerInfo['customerId']);
             $quote->getPayment()->importData($extraPaymentData);
+            $quote->setTotalsCollectedFlag(false);
             $quote->collectTotals();
             $this->quoteRepository->save($quote);
             // Create Order From Quote


### PR DESCRIPTION
The collectTotals function was being called internally after shipping updates so when the explicit call to `$quote->collectTotals()` was being called later on the totals collected flag was already set to true so the quote was not being recalculated. Setting the flag to false will force Magento to recalculate totals.