### PR TITLE
Fix recurring order placement for products with quantity > 1

### DIFF
--- a/Model/RecurringOrder/CreateRecurringOrder.php
+++ b/Model/RecurringOrder/CreateRecurringOrder.php
@@ -317,7 +317,7 @@ class CreateRecurringOrder
                     } else {
                         $paramsObject = [
                             'qty' => $item['qty'],
-                            'custom_price' => $item['finalPrice']
+                            'custom_price' => $item['finalPrice'] / intval($item['qty'])
                         ];
                     }
                     $product = $this->productRepository->getById($productId, false, null, true);
@@ -424,7 +424,7 @@ class CreateRecurringOrder
             'bundle_option' => $getBundleOptions,
             'bundle_option_qty' => $getBundleOptionsQty,
             'qty' => intval($item['qty']),
-            'custom_price' => $item['finalPrice']
+            'custom_price' => $item['finalPrice'] / intval($item['qty'])
         ];
     }
 
@@ -452,7 +452,7 @@ class CreateRecurringOrder
         }
         return [
             'qty' => $item['qty'],
-            'custom_price' => $item['finalPrice']
+            'custom_price' => $item['finalPrice'] / intval($item['qty'])
         ];
     }
 


### PR DESCRIPTION
Current behavior is broken in that it will take in a finalPrice and multiply it by a product quantity. This is incorrect because the finalPrice field in order xml is already a multiplied value so you're charging customers double. This will address the issue by dividing the finalPrice by quantity. The reason that this approach is taken is so that we can ensure that discounts are taken into consideration when charging the customer.