### PR TITLE
Add ability to run unit tests locally and add support for CDATA

### DIFF
--- a/Helper/ProductSync/XmlHelper.php
+++ b/Helper/ProductSync/XmlHelper.php
@@ -22,6 +22,28 @@ use Magento\Store\Api\WebsiteRepositoryInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Framework\EntityManager\MetadataPool;
 
+
+class SimpleXMLElementExtended extends \SimpleXMLElement {
+
+    /**
+     * https://stackoverflow.com/a/20511976
+     * Adds a child with $value inside CDATA
+     * @param unknown $name
+     * @param unknown $value
+     */
+    public function addChildWithCDATA($name, $value = NULL) {
+      $new_child = $this->addChild($name);
+  
+      if ($new_child !== NULL) {
+        $node = dom_import_simplexml($new_child);
+        $no   = $node->ownerDocument;
+        $node->appendChild($no->createCDATASection($value));
+      }
+  
+      return $new_child;
+    }
+  }
+
 /**
  * Class XmlHelper
  * @package Ordergroove\Subscription\Helper\ProductSync
@@ -174,7 +196,7 @@ class XmlHelper
         $linkField = $metadata->getLinkField();
         try {
             $this->logger->info("In createWebsiteProductsXml for: ".$websiteId);
-            $this->xml = new \SimpleXMLElement('<products/>');
+            $this->xml = new SimpleXMLElementExtended('<products/>');
             $collection = $this->productFactory->create()->getCollection();
 
             $entityType = $collection->getEntity()->getType();
@@ -273,7 +295,7 @@ class XmlHelper
             return;
         }
         $productXml = $this->xml->addChild('product');
-        $productXml->addChild('name', str_replace($symbols["search"], $symbols["replace"], $productData['name']));
+        $productXml->addChildWithCDATA('name', str_replace($symbols["search"], $symbols["replace"], $productData['name']));
         $productXml->addChild('product_id', $productData['entity_id']);
         $productXml->addChild('sku', $productData['sku']);
         $productXml->addChild('price', $productData['price']);

--- a/Test/Unit/Block/Catalog/GetProductDataTest.php
+++ b/Test/Unit/Block/Catalog/GetProductDataTest.php
@@ -44,7 +44,7 @@ class GetProductDataTest extends TestCase
      * setUp
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
         $this->registry = $this->createPartialMock(Registry::class, ['registry']);

--- a/Test/Unit/Block/MainJsTest.php
+++ b/Test/Unit/Block/MainJsTest.php
@@ -34,7 +34,7 @@ class MainJsTest extends TestCase
     /**
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 
@@ -58,7 +58,7 @@ class MainJsTest extends TestCase
     /**
      * @return void
      */
-    public function testGetMainJsUrl()
+    public function testGetMainJsUrl() : void
     {
         $this->urlBuilder->expects($this->once())->method("getPublicIdUrl")->willReturn("https://test.com");
         $this->assertEquals("https://test.com", $this->mainJs->getMainJsUrl());

--- a/Test/Unit/Block/MsiJsTest.php
+++ b/Test/Unit/Block/MsiJsTest.php
@@ -41,7 +41,7 @@ class MsiJsTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Block/System/Config/CheckConnectionTest.php
+++ b/Test/Unit/Block/System/Config/CheckConnectionTest.php
@@ -32,7 +32,7 @@ class CheckConnectionTest extends TestCase
      */
     protected $layout;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $objectManager = new ObjectManager($this);
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManager\ObjectManager::class);
@@ -52,7 +52,7 @@ class CheckConnectionTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
     }
 

--- a/Test/Unit/Controller/Msi/IndexTest.php
+++ b/Test/Unit/Controller/Msi/IndexTest.php
@@ -60,7 +60,7 @@ class IndexTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManagerMock = $this->createMock(\Magento\Framework\ObjectManager\ObjectManager::class);
         $this->request = $this->createMock(\Magento\Framework\App\Request\Http::class);

--- a/Test/Unit/Controller/Subscription/PlaceOrderTest.php
+++ b/Test/Unit/Controller/Subscription/PlaceOrderTest.php
@@ -84,7 +84,7 @@ class PlaceOrderTest extends TestCase
      */
     protected $request;
 
-    public function setUp()
+    public function setUp() : void
     {
         $objectManager = new ObjectManager($this);
         $this->context = $this->createMock(Context::class);

--- a/Test/Unit/Helper/ConfigHelperTest.php
+++ b/Test/Unit/Helper/ConfigHelperTest.php
@@ -35,7 +35,7 @@ class ConfigHelperTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Helper/ProductSync/ProductSyncTest.php
+++ b/Test/Unit/Helper/ProductSync/ProductSyncTest.php
@@ -29,7 +29,7 @@ class ProductSyncTest extends TestCase
      * @var ObjectManager
      */
     protected $objectManager;
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
         $this->productSync = $this->objectManager->getObject(ProductSync::class);
@@ -50,7 +50,7 @@ class ProductSyncTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
     }
 

--- a/Test/Unit/Helper/ProductSync/SftpHelperTest.php
+++ b/Test/Unit/Helper/ProductSync/SftpHelperTest.php
@@ -43,7 +43,7 @@ class SftpHelperTest extends TestCase
      */
     protected $infoLogger;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 
@@ -74,7 +74,7 @@ class SftpHelperTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
     }
 

--- a/Test/Unit/Helper/ProductSync/XmlHelperTest.php
+++ b/Test/Unit/Helper/ProductSync/XmlHelperTest.php
@@ -57,7 +57,7 @@ class XmlHelperTest extends TestCase
      */
     private $scopeConfig;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
         $this->storeRepository = $this->getMockBuilder(StoreRepository::class)
@@ -109,7 +109,7 @@ class XmlHelperTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
     }
 

--- a/Test/Unit/Helper/PurchasePost/DataMapper/DataMapHelperTest.php
+++ b/Test/Unit/Helper/PurchasePost/DataMapper/DataMapHelperTest.php
@@ -191,7 +191,7 @@ class DataMapHelperTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Helper/PurchasePost/DataMapper/DataMapTest.php
+++ b/Test/Unit/Helper/PurchasePost/DataMapper/DataMapTest.php
@@ -43,7 +43,7 @@ class DataMapTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Helper/PurchasePost/SendPurchasePostDataTest.php
+++ b/Test/Unit/Helper/PurchasePost/SendPurchasePostDataTest.php
@@ -55,7 +55,7 @@ class SendPurchasePostDataTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Helper/RecurringOrderHelper/CreateRecurringOrderHelperTest.php
+++ b/Test/Unit/Helper/RecurringOrderHelper/CreateRecurringOrderHelperTest.php
@@ -69,7 +69,7 @@ class CreateRecurringOrderHelperTest extends TestCase
     /**
      * Constructor
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Helper/UrlBuilderHelperTest.php
+++ b/Test/Unit/Helper/UrlBuilderHelperTest.php
@@ -29,7 +29,7 @@ class UrlBuilderHelperTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/Authentication/ValidateAuthorizationTest.php
+++ b/Test/Unit/Model/Authentication/ValidateAuthorizationTest.php
@@ -29,7 +29,7 @@ class ValidateAuthorizationTest extends TestCase
      */
     protected $validateAuthorization;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/Config/ConfigProviderTest.php
+++ b/Test/Unit/Model/Config/ConfigProviderTest.php
@@ -39,7 +39,7 @@ class ConfigProviderTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/Config/Source/SyncSelectTest.php
+++ b/Test/Unit/Model/Config/Source/SyncSelectTest.php
@@ -19,7 +19,7 @@ class SyncSelectTest extends TestCase
      */
     protected $timeZoneInterface;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $objectManager = new ObjectManager($this);
         $this->timeZoneInterface = $this->getMockBuilder(Timezone::class)
@@ -35,7 +35,7 @@ class SyncSelectTest extends TestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
     }
 

--- a/Test/Unit/Model/Config/TokenBuilderTest.php
+++ b/Test/Unit/Model/Config/TokenBuilderTest.php
@@ -31,7 +31,7 @@ class TokenBuilderTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/Config/UrlBuilderTest.php
+++ b/Test/Unit/Model/Config/UrlBuilderTest.php
@@ -37,7 +37,7 @@ class UrlBuilderTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/Cookie/OgAuthCookieTest.php
+++ b/Test/Unit/Model/Cookie/OgAuthCookieTest.php
@@ -165,7 +165,7 @@ class OgAuthCookieTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/Customer/UpdateDataApiHelper/UpdateDataApiHelperTest.php
+++ b/Test/Unit/Model/Customer/UpdateDataApiHelper/UpdateDataApiHelperTest.php
@@ -67,7 +67,7 @@ class UpdateDataApiHelperTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/Customer/UpdateDataApiTest.php
+++ b/Test/Unit/Model/Customer/UpdateDataApiTest.php
@@ -90,7 +90,7 @@ class UpdateDataApiTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Model/RecurringOrder/CreateRecurringOrderTest.php
+++ b/Test/Unit/Model/RecurringOrder/CreateRecurringOrderTest.php
@@ -83,7 +83,7 @@ class CreateRecurringOrderTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
         $this->product = $this->getMockBuilder(Product::class)

--- a/Test/Unit/Model/Request/ValidateRequestTest.php
+++ b/Test/Unit/Model/Request/ValidateRequestTest.php
@@ -31,7 +31,7 @@ class ValidateRequestTest extends TestCase
     /**
      * Set Up
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
         $this->request = $this->getMockBuilder(Http::class)

--- a/Test/Unit/Model/Signature/SignatureTest.php
+++ b/Test/Unit/Model/Signature/SignatureTest.php
@@ -34,7 +34,7 @@ class SignatureTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Observer/CustomerUpdate/ChangeInEmailTest.php
+++ b/Test/Unit/Observer/CustomerUpdate/ChangeInEmailTest.php
@@ -111,7 +111,7 @@ class ChangeInEmailTest extends Testcase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Observer/DataAssignObserverTest.php
+++ b/Test/Unit/Observer/DataAssignObserverTest.php
@@ -27,7 +27,7 @@ class DataAssignObserverTest extends TestCase
      * @var ObjectManager
      */
     private $objectManager;
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Observer/Sales/SendPurchasePostTest.php
+++ b/Test/Unit/Observer/Sales/SendPurchasePostTest.php
@@ -63,7 +63,7 @@ class SendPurchasePostTest extends Testcase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Plugin/Account/Login/CreateCookieTest.php
+++ b/Test/Unit/Plugin/Account/Login/CreateCookieTest.php
@@ -114,7 +114,7 @@ class CreateCookieTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Plugin/Account/Logout/DeleteCookieTest.php
+++ b/Test/Unit/Plugin/Account/Logout/DeleteCookieTest.php
@@ -57,7 +57,7 @@ class DeleteCookieTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Plugin/Account/Telephone/ChangeInTelephoneTest.php
+++ b/Test/Unit/Plugin/Account/Telephone/ChangeInTelephoneTest.php
@@ -134,7 +134,7 @@ class ChangeInTelephoneTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
         $this->customerSession = $this->getMockBuilder(Session::class)

--- a/Test/Unit/Plugin/Checkout/CustomerData/AbstractItemPluginTest.php
+++ b/Test/Unit/Plugin/Checkout/CustomerData/AbstractItemPluginTest.php
@@ -32,7 +32,7 @@ class AbstractItemPluginTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Plugin/Quote/Model/Quote/ShippingRatePluginTest.php
+++ b/Test/Unit/Plugin/Quote/Model/Quote/ShippingRatePluginTest.php
@@ -23,7 +23,7 @@ class ShippingRatePluginTest extends TestCase
      * setUp
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,12 @@
         "psr-4": {
             "Ordergroove\\Subscription\\": ""
         }
+    },
+    "repositories": [{
+        "type": "composer",
+        "url": "https://repo.magento.com/"
+    }],
+    "require-dev": {
+        "phpunit/phpunit": "9.5.x-dev"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,10 @@
+<phpunit bootstrap="vendor/autoload.php">
+    <php>
+        <ini name="display_errors" value="true"/>
+   </php>
+    <testsuites>
+        <testsuite name="all">
+            <directory>Test/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
This will add support for the product sync process to consumer product names with special characters. Additionally, this will allow a local phpunit test run. The tests are currently failing due to the reliance on Magento modules, a follow-up PR will address this.