### PR TITLE
Update place-order-mixin.js

### DIFF
--- a/view/frontend/web/js/model/place-order-mixin.js
+++ b/view/frontend/web/js/model/place-order-mixin.js
@@ -22,8 +22,8 @@ define([
                             'og_optins': JSON.stringify(productIds)
                         }
                     }
-                    paymentData['additional_data']['customer_id'] = customerData.id;
                 }
+                paymentData['additional_data']['customer_id'] = customerData.id;
             }
 
             return originalAction(paymentData, messageContainer).fail(


### PR DESCRIPTION
The original fix () to pass in the customer id during checkout fixed the problem for customers checking out with Ordergroove eligible products in their cart but it also needs to address checkouts without any eligible products as well.