### PR TITLE
Hide flat rate shipping for non recurring orders

### DIFF
--- a/Model/Carrier/DisableFlatratePlugin.php
+++ b/Model/Carrier/DisableFlatratePlugin.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ordergroove\Subscription\Model\Carrier;
+
+class Flatrate{
+
+    protected $_checkoutSession;
+    protected $_scopeConfig;
+    protected $_customerSession;
+
+    public function __construct(
+        \Magento\Checkout\Model\Session $checkoutSession,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Customer\Model\Session $customerSession
+    ) {
+        $this->_storeManager = $storeManager;
+        $this->_checkoutSession = $checkoutSession;
+        $this->_scopeConfig = $scopeConfig;
+        $this->_customerSession = $customerSession;
+    }
+
+    public function afterCollectRates(\Magento\OfflineShipping\Model\Carrier\Flatrate $Flatrate, $result)
+    {   
+        $url = $this->_storeManager->getStore()->getCurrentUrl(false);
+        $path = parse_url($url)['path'];
+        if ($path == '/ordergroove/subscription/placeorder') {
+            return $result;
+        }
+        return false;
+    }  
+
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\OfflineShipping\Model\Carrier\Flatrate">
+        <plugin name="ordergroove_disable_flatrate_on_checkout" type="Ordergroove\Subscription\Model\Carrier\DisableFlatratePlugin" sortOrder="1" />
+    </type> 
     <type name="Magento\Config\Model\Config\TypePool">
         <arguments>
             <argument name="sensitive" xsi:type="array">


### PR DESCRIPTION
In order to use flat rate shipping powered by Ordergroove, Magento flat rate shipping has to be enabled. Once you enabled flat rate shipping however, all customer check outs start seeing this shipping option. This PR will make sure that flat rate shipping can be used for recurring orders without exposing it in other areas such as checkout