### PR TITLE
Add explicit check to addToCart response

### DIFF
--- a/Model/RecurringOrder/CreateRecurringOrder.php
+++ b/Model/RecurringOrder/CreateRecurringOrder.php
@@ -321,7 +321,11 @@ class CreateRecurringOrder
                         ];
                     }
                     $product = $this->productRepository->getById($productId, false, null, true);
-                    $quote->addProduct($product, new DataObject($paramsObject));
+                    $response = $quote->addProduct($product, new DataObject($paramsObject));
+
+                    if (is_string($response)) {
+                        throw new RecurringOrderException(__("Unexpected response when trying to add product to the cart: ".$response), null, "020");
+                    }
                 }
             } else {
                 $stockId = null;
@@ -336,7 +340,11 @@ class CreateRecurringOrder
                         $paramsObject = $this->addSimpleAndConfigurableToCart($productId, $item, $stockId, $websiteId);
                     }
                     $product = $this->productRepository->getById($productId, false, null, true);
-                    $quote->addProduct($product, new DataObject($paramsObject));
+                    $response = $quote->addProduct($product, new DataObject($paramsObject));
+
+                    if (is_string($response)) {
+                        throw new RecurringOrderException(__("Unexpected response when trying to add product to the cart: ".$response), null, "020");
+                    }
                 }
             }
 


### PR DESCRIPTION
During recurring order placement, when there is an error sometimes the response from addToCart is an error message but it's being returned in a form of a plain string. Since this is an unexpected response, our code fails later on with an unexpected exception and results in a 500 response code. For example a certain module was throwing:`The product's required option(s) weren't entered. Make sure the options are entered and try again.` which resulted in this error string.

The code introduced in this PR will now surface this as a response message so that it can be easily debugged.