### PR TITLE
Fix class name for flat rate shipping

### DIFF
--- a/Model/Carrier/DisableFlatratePlugin.php
+++ b/Model/Carrier/DisableFlatratePlugin.php
@@ -2,7 +2,7 @@
 
 namespace Ordergroove\Subscription\Model\Carrier;
 
-class Flatrate{
+class DisableFlatratePlugin{
 
     protected $_checkoutSession;
     protected $_scopeConfig;


### PR DESCRIPTION
There was a change to the class name which was missed during the initial push to git origin when 1.0.4 was introduced.