### PR TITLE
Automatically update cart totals when customers change subscription state

### DIFF
--- a/view/frontend/web/js/switch-subscription.js
+++ b/view/frontend/web/js/switch-subscription.js
@@ -18,7 +18,9 @@ define([
                     var deferred = $.Deferred();
                     
                     customerData.reload(sections, true);
-                    getCartTotals([], deferred);
+                    if (e.target.closest("og-offer").getAttribute("location") === "cart") {
+                        getCartTotals([], deferred);
+                    }
                 }
             }
         });
@@ -31,8 +33,10 @@ define([
                 var sections = ['cart'];
                 var deferred = $.Deferred();
                 
-                customerData.reload(sections, true);                
-                getCartTotals([], deferred);
+                customerData.reload(sections, true);
+                if (e.target.closest("og-offer").getAttribute("location") === "cart") {
+                    getCartTotals([], deferred);
+                }
             }
         });
     });

--- a/view/frontend/web/js/switch-subscription.js
+++ b/view/frontend/web/js/switch-subscription.js
@@ -1,8 +1,9 @@
 define([
     'jquery',
     'jquery/jquery.cookie',
+    'Magento_Checkout/js/action/get-totals',
     'Magento_Customer/js/customer-data'
-], function ($, cookie, customerData) {
+], function ($, cookie, getCartTotals, customerData) {
     $(document).ready(function ($) {
         $(document).on('click', 'og-optin-button', function (e) {
             e.preventDefault();
@@ -14,7 +15,10 @@ define([
                     return false;
                 } else {
                     var sections = ['cart'];
+                    var deferred = $.Deferred();
+                    
                     customerData.reload(sections, true);
+                    getCartTotals([], deferred);
                 }
             }
         });
@@ -25,7 +29,10 @@ define([
             $.cookie('product_subscribed_' + unsubscribedProduct, false);
             if (window.location.href.indexOf("checkout") > -1) {
                 var sections = ['cart'];
-                customerData.reload(sections, true);
+                var deferred = $.Deferred();
+                
+                customerData.reload(sections, true);                
+                getCartTotals([], deferred);
             }
         });
     });


### PR DESCRIPTION
This will make it so that the cart totals are updated in the cart when a customer opts into and out of subscriptions. The reason that this is important is to ensure proper cost messaging in the cart for cases where an initial order incentive (IOI) is enabled for a product.