### PR TITLE
[FIX] Og_Subscription/js/switch-subscription deps

### DIFF
--- a/view/frontend/web/js/switch-subscription.js
+++ b/view/frontend/web/js/switch-subscription.js
@@ -1,11 +1,33 @@
 define([
     'jquery',
     'jquery/jquery.cookie',
-    'Magento_Customer/js/customer-data',
-    'Magento_Checkout/js/model/quote',
-    'Magento_Checkout/js/model/cart/totals-processor/default'
-], function ($, cookie, customerData, quote, totalsDefaultProvider) {
+    'Magento_Customer/js/customer-data'
+], function ($, cookie, customerData) {
     $(document).ready(function ($) {
+        /**
+         * Estimate cart totals before refresh on Checkout pages
+         *
+         * Prevent attempting to load Magento_Checkout models on every page
+         *
+         * @param {Object} e
+         * @return void
+         */
+        function estimateTotals (e) {
+            if (window.checkoutConfig) {
+                require([
+                    'Magento_Checkout/js/model/quote',
+                    'Magento_Checkout/js/model/cart/totals-processor/default'
+                ], function (quote, totalsDefaultProvider) {
+                    var sections = ['cart'];
+                    customerData.reload(sections, true);
+
+                    if (e.target.closest("og-offer").getAttribute("location") === "cart") {
+                        totalsDefaultProvider.estimateTotals(quote.shippingAddress());
+                    }
+                });
+            }
+        }
+
         $(document).on('click', 'og-optin-button', function (e) {
             e.preventDefault();
             var subscribedProduct = $(this).closest('og-offer').attr("product");
@@ -15,12 +37,7 @@ define([
                     location.href = window.BASE_URL + 'ordergroove/checksubscription/index';
                     return false;
                 } else {
-                    var sections = ['cart'];
-                    customerData.reload(sections, true);
-                    
-                    if (e.target.closest("og-offer").getAttribute("location") === "cart") {
-                        totalsDefaultProvider.estimateTotals(quote.shippingAddress());
-                    }
+                    estimateTotals(e);
                 }
             }
         });
@@ -30,12 +47,7 @@ define([
             var unsubscribedProduct = $(this).closest('og-offer').attr("product");
             $.cookie('product_subscribed_' + unsubscribedProduct, false);
             if (window.location.href.indexOf("checkout") > -1) {
-                var sections = ['cart'];
-                
-                customerData.reload(sections, true);
-                if (e.target.closest("og-offer").getAttribute("location") === "cart") {
-                    totalsDefaultProvider.estimateTotals(quote.shippingAddress());
-                }
+                estimateTotals(e);
             }
         });
     });


### PR DESCRIPTION
Fix Ordergroove_Subscription/js/switch-subscription module definition dependencies requiring `window.checkoutConfig` causing errors.

Fix Issue #24.

Only load models that require `window.checkoutConfig` if it is available. Stop errors caused by `window.checkoutConfig` being undefined in Magento_Checkout/js/model/quote & Magento_Checkout/js/model/cart/totals-processor/default.

The workflow that uses these models is the same the click event listeners for both the 'og-optin-button' & 'og-optout-button', with the expectation that the page URL path begins with "checkout". Add `estimateTotals` function that runs the cart totals-processor `estimateTotals()` workflow, but only if the `window.checkoutConfig` is available, as it would be within the already checked for "checkout" URL path pages.  Only require classes that depend on `window.checkoutConfig` if it is defined.  Do nothing  if it is not defined. This does not change any of the current expected functionality of the switch-scripts file, continuing to run these `estimateTotals()` calls where they would run before. It does prevent attempting to load models that are unavailable due to missing required data dependencies, preventing calls that cannot be made anyway and the errors that accompany those bad calls.  The data is available and the calls are made in the places where it was expected to be available before.